### PR TITLE
Fix ENOENT Error on Windows by Creating Missing C:\tmp\napi_session_id Directory and Add Cross-Platform Support for NODE_ENV with Cross-Env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5314,6 +5314,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -12297,7 +12315,7 @@
     },
     "packages/cli": {
       "name": "@nanoapi.io/napi",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "axios": "^1.7.7",
         "express": "^4.21.1",
@@ -12322,6 +12340,7 @@
         "@types/prompts": "^2.4.9",
         "@types/uuid": "^10.0.0",
         "@types/yargs": "^17.0.33",
+        "cross-env": "^7.0.3",
         "nodemon": "^3.1.7",
         "pkg": "^5.8.1",
         "prettier": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "dev:app": "npm run dev --workspace packages/app",
-    "dev:cli": "NODE_ENV=development npm run dev --workspace packages/cli",
+    "dev:cli": "npm run dev --workspace packages/cli",
     "build:cleanup": "rm -rf packages/cli/dist && rm -rf packages/app/dist",
     "build:packages": "npm run build --workspaces",
     "build:copy-dist": "cp -r packages/app/dist packages/cli/dist/app_dist",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     }
   },
   "scripts": {
-    "dev": "NODE_ENV=development nodemon src/index.ts",
+    "dev": "cross-env NODE_ENV=development nodemon src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest",
@@ -65,6 +65,7 @@
     "@types/prompts": "^2.4.9",
     "@types/uuid": "^10.0.0",
     "@types/yargs": "^17.0.33",
+    "cross-env": "^7.0.3",
     "nodemon": "^3.1.7",
     "pkg": "^5.8.1",
     "prettier": "3.3.3",

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "events";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { v4 as uuidv4 } from "uuid";
+import os from "os";
 
 export enum TelemetryEvents {
   APP_START = "app_start",
@@ -27,7 +28,7 @@ const telemetry = new EventEmitter();
 const TELEMETRY_ENDPOINT =
   process.env.TELEMETRY_ENDPOINT ||
   "https://napi-watchdog-api-gateway-33ge7a49.nw.gateway.dev/telemetryHandler";
-const SESSION_FILE_PATH = join("/tmp", "napi_session_id");
+const SESSION_FILE_PATH = join(os.tmpdir(), "napi_session_id");
 
 // getSessionId generates a new session ID and cache it in SESSION_FILE_PATH
 function getSessionId() {


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
This PR addresses cross-platform compatibility issues in the development environment, specifically enhancing support for Windows users.

### Fixes and Improvements
Windows Compatibility: Resolved NODE_ENV setting issue by integrating cross-env, ensuring environment variables are correctly set across all platforms.
Cross-Platform CLI Compatibility: The CLI development environment's overall compatibility has been improved, making it more accessible and reliable for developers on Windows and UNIX-based systems.

## Related Issue
Issue Link (https://github.com/nanoapi-io/napi/issues/38)
Issue Number: #38

## Motivation and Context
This change improves cross-platform compatibility by resolving issues with setting temp directory and NODE_ENV on Windows.

## How Has This Been Tested?
Tested two main changes:
Cross-env Addition:
Tested on Windows 11
Verified cross-env NODE_ENV=development works
Temporary Directory Fix:
Tested on Windows that we are able to initialize a project with no issues

## Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My code follows the code style of this project.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
