### PR TITLE
Fixed extractor not picking the right dependencies

### DIFF
--- a/packages/cli/src/languagePlugins/csharp/extractor/index.ts
+++ b/packages/cli/src/languagePlugins/csharp/extractor/index.ts
@@ -65,7 +65,12 @@ export class CSharpExtractor {
    */
   private findDependencies(symbol: SymbolNode): SymbolNode[] {
     const dependencies: SymbolNode[] = [];
-    const symbolDependencies = this.manifest[symbol.filepath]?.dependencies;
+    const symbolfullname =
+      symbol.namespace !== ""
+        ? symbol.namespace + "." + symbol.name
+        : symbol.name;
+    const symbolDependencies =
+      this.manifest[symbol.filepath]?.symbols[symbolfullname].dependencies;
     if (symbolDependencies) {
       for (const dependency of Object.values(symbolDependencies)) {
         for (const depsymbol of Object.values(dependency.symbols)) {


### PR DESCRIPTION
## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description

Fixed the extractor taking the file dependencies instead of the symbol dependencies for a single symbol's extraction.
